### PR TITLE
remove cache flushing on error

### DIFF
--- a/lib/duplicate.php
+++ b/lib/duplicate.php
@@ -52,7 +52,6 @@ if( !class_exists( 'MUCD_Duplicate' ) ) {
             $user_id = MUCD_Duplicate::create_admin($email, $domain);
 
             if ( is_wp_error( $user_id ) ) {
-                wp_cache_flush();
                 $form_message['error'] = $user_id->get_error_message();
                 return $form_message;
             }
@@ -63,7 +62,6 @@ if( !class_exists( 'MUCD_Duplicate' ) ) {
             $wpdb->show_errors();
 
             if ( is_wp_error( $to_site_id ) ) {
-                wp_cache_flush();
                 $form_message['error'] = $to_site_id->get_error_message();
                 return $form_message;
             }


### PR DESCRIPTION
We have a very large (3000 websites) multisite install of Wordpress and are using this plugin to clone websites on a very regular (multiple times a day) basis. This is causing repeated cache flushing, which is having an impact on performance.

In MUCD_Duplicate::duplicate_site there are two wp_cache_flush calls if there is an error, but I do not think they are actually needed. This pull request removes them.