### PR TITLE
fix replacement in serialized objects

### DIFF
--- a/lib/data.php
+++ b/lib/data.php
@@ -293,8 +293,8 @@ if( !class_exists( 'MUCD_Data' ) ) {
                 else if(is_object($row[$field]) || $row[$field] instanceof __PHP_Incomplete_Class) { // Étrange fonctionnement avec Google Sitemap...
                     $array_object = (array) $row[$field];
                     $array_object = self::replace_recursive($array_object, $from_string, $to_string);
-                    foreach($array_object as $key => $field) {
-                        $row[$field]->$key = $field;
+                    foreach($array_object as $key => $inner_field) {
+                        $row[$field]->$key = $inner_field;
                     }
                 }
                 else {


### PR DESCRIPTION
# Issue

Cloning fails while trying to replace `wp_` in `option_value` of the option `_site_transient_update_plugins`.

## Environment

- WordPress 6.0.2
- MultiSite Clone Duplicator 1.5.3
- PHP 8.1.7

# Bug

Variable reuse side effect: The `$field` variable is reassigned by the foreach loop, however the loop body expects the original value of `$field`.

# Solution

Do not reuse the variable.